### PR TITLE
Fetch related records

### DIFF
--- a/model/fetch.js
+++ b/model/fetch.js
@@ -22,9 +22,64 @@ function fetch(options) {
   });
 }
 
-function build_request({ object }) {
-  return {
+function build_request({ config, object }) {
+  const request = {
     method: 'get',
-    url: `${object.__config.base_url}${object.endpoint}/${object.id}`,
+    url: `${config.base_url}${object.endpoint}/${object.id}`,
   }
+  const include_param = get_include_param({ object, related: config.related });
+
+  if (include_param) {
+    request.url += `?include=${include_param}`;
+  }
+
+  return request;
+}
+
+function get_include_param({ object, related }) {
+  let include_param = '';
+
+  if (!related) {
+    return include_param;
+  }
+
+  switch (typeof related) {
+    case 'string':
+      include_param += calculate_related_paths({ object, prop: related });
+      break;
+
+    case 'object':
+      if (Array.isArray(related)) {
+        include_param += related
+          .map(item => get_include_param({ object, related: item }))
+          .filter(item => item)
+          .join(',');
+      } else {
+        include_param += Object.keys(related)
+          .map(item => get_include_param({ object, related: item }))
+          .filter(item => item)
+          .join(',');
+      }
+      break;
+
+    case 'boolean':
+      include_param += Object.keys(object.__maps)
+        .map(item => get_include_param({ object, related: item }))
+        .filter(item => item)
+        .join(',');
+      break;
+  }
+
+  return include_param;
+}
+
+function calculate_related_paths({ object, prop }) {
+  const directive = object.__maps[prop];
+
+  if (typeof directive !== 'string' || !directive.match(/^relationships\./)) {
+    // @TODO: Probably good to console.warn() here.
+    return '';
+  }
+
+  return directive.replace(/^relationships\./, '');
 }

--- a/model/fetch.js
+++ b/model/fetch.js
@@ -54,19 +54,17 @@ function get_include_param({ object, related }) {
           .map(item => get_include_param({ object, related: item }))
           .filter(item => item)
           .join(',');
-      } else {
-        include_param += Object.keys(related)
+      }
+      // @TODO: Support non-iterable objects (for nested relationships?)
+      break;
+
+    case 'boolean':
+      if (related) {
+        include_param += Object.keys(object.__maps)
           .map(item => get_include_param({ object, related: item }))
           .filter(item => item)
           .join(',');
       }
-      break;
-
-    case 'boolean':
-      include_param += Object.keys(object.__maps)
-        .map(item => get_include_param({ object, related: item }))
-        .filter(item => item)
-        .join(',');
       break;
   }
 

--- a/model/fetch.js
+++ b/model/fetch.js
@@ -1,8 +1,11 @@
+const _ = require('lodash');
+
 module.exports = fetch;
 
-function fetch() {
+function fetch(options) {
   const object = this;
-  const request = build_request({ object });
+  const config = _.merge({}, object.__config, options);
+  const request = build_request({ config, object });
   const axios = object.__axios;
 
   return axios(request).then(response => {

--- a/model/index.js
+++ b/model/index.js
@@ -13,7 +13,7 @@ const CONFIG = Symbol.for('Jsonmonger.config');
 
 module.exports = Model;
 
-function Model(maps, { axios, config = global[CONFIG] } = {}) {
+function Model(maps, config = {}) {
   validate(maps);
 
   const props = _.cloneDeep(maps);
@@ -56,7 +56,7 @@ function Model(maps, { axios, config = global[CONFIG] } = {}) {
         configurable: false,
       },
       __axios: {
-        value: axios || require('axios'),
+        value: config.axios || require('axios'),
         enumerable: false,
         writable: false,
         configurable: false,
@@ -68,9 +68,7 @@ function Model(maps, { axios, config = global[CONFIG] } = {}) {
         configurable: false,
       },
       __config: {
-        value: {
-          base_url: config.base_url,
-        },
+        value: _.merge({}, global[CONFIG], config),
         enumerable: false,
         writable: true,
         configurable: false,

--- a/test/fixtures/models/Image.js
+++ b/test/fixtures/models/Image.js
@@ -1,0 +1,13 @@
+const Model = require('../../../').Model;
+const Person = require('./Person');
+
+module.exports = ({ axios } = {}) => new Model({
+  type: 'image',
+  endpoint: '/images',
+  url: 'attributes.src',
+  alt: 'attributes.alt',
+  credit: 'relationships.author',
+}, {
+  axios,
+  related: [ Person ],
+});

--- a/test/fixtures/models/Image.js
+++ b/test/fixtures/models/Image.js
@@ -1,5 +1,4 @@
 const Model = require('../../../').Model;
-const Person = require('./Person');
 
 module.exports = ({ axios } = {}) => new Model({
   type: 'image',
@@ -9,5 +8,4 @@ module.exports = ({ axios } = {}) => new Model({
   credit: 'relationships.author',
 }, {
   axios,
-  related: [ Person ],
 });

--- a/test/fixtures/models/Paragraph.js
+++ b/test/fixtures/models/Paragraph.js
@@ -1,0 +1,7 @@
+const Model = require('../../../').Model;
+
+module.exports = ({ axios } = {}) => new Model({
+  type: 'paragraph',
+  endpoint: '/paragraphs',
+  text: 'attributes.text',
+}, { axios });

--- a/test/fixtures/models/Person.js
+++ b/test/fixtures/models/Person.js
@@ -1,5 +1,4 @@
 const Model = require('../../../').Model;
-const Role = require('./Role');
 
 module.exports = ({ axios } = {}) => new Model({
   type: 'person',
@@ -31,5 +30,4 @@ module.exports = ({ axios } = {}) => new Model({
   roles: 'relationships.roles',
 }, {
   axios,
-  related: [ Role ],
 });

--- a/test/fixtures/models/Person.js
+++ b/test/fixtures/models/Person.js
@@ -1,0 +1,35 @@
+const Model = require('../../../').Model;
+const Role = require('./Role');
+
+module.exports = ({ axios } = {}) => new Model({
+  type: 'person',
+  endpoint: '/people',
+  fullName: 'attributes.name',
+  firstName: function (value) {
+    if (value) {
+      const names = this.fullName.split(' ');
+      names[0] = value;
+      this.fullName = names.join(' ');
+      return value;
+    } else {
+      return this.fullName.split(' ')[0];
+    }
+  },
+  lastName: function (value) {
+    if (value) {
+      const names = this.fullName.split(' ');
+      const lastName = value.split(' ');
+      names.splice(1, lastName.length, ...lastName);
+      this.fullName = names.join(' ');
+      return value;
+    } else {
+      return this.fullName.split(' ').slice(1).join(' ');
+    }
+  },
+  bio: 'attributes.biography',
+  alias: 'attributes.path.alias',
+  roles: 'relationships.roles',
+}, {
+  axios,
+  related: [ Role ],
+});

--- a/test/fixtures/models/Post.js
+++ b/test/fixtures/models/Post.js
@@ -1,0 +1,17 @@
+const Model = require('../../../').Model;
+const Image = require('./Image');
+const Paragraph = require('./Paragraph');
+const Person = require('./Person');
+
+module.exports = ({ axios } = {}) => new Model({
+  type: 'post',
+  endpoint: '/posts',
+  title: 'attributes.title',
+  subtitle: 'attributes.sub_title',
+  author: 'relationships.author',
+  body: 'relationships.body',
+  topics: 'relationships.category',
+}, {
+  axios,
+  related: [ Image, Paragraph, Person ],
+});

--- a/test/fixtures/models/Post.js
+++ b/test/fixtures/models/Post.js
@@ -1,9 +1,6 @@
 const Model = require('../../../').Model;
-const Image = require('./Image');
-const Paragraph = require('./Paragraph');
-const Person = require('./Person');
 
-module.exports = ({ axios } = {}) => new Model({
+module.exports = (config = {}) => new Model({
   type: 'post',
   endpoint: '/posts',
   title: 'attributes.title',
@@ -11,7 +8,4 @@ module.exports = ({ axios } = {}) => new Model({
   author: 'relationships.author',
   body: 'relationships.body',
   topics: 'relationships.category',
-}, {
-  axios,
-  related: [ Image, Paragraph, Person ],
-});
+}, config);

--- a/test/fixtures/models/Role.js
+++ b/test/fixtures/models/Role.js
@@ -1,0 +1,8 @@
+const Model = require('../../../').Model;
+
+module.exports = ({ axios } = {}) => new Model({
+  type: 'role',
+  endpoint: '/roles',
+  name: 'attributes.name',
+  url: 'attributes.path.alias',
+});

--- a/test/fixtures/post.json
+++ b/test/fixtures/post.json
@@ -27,6 +27,12 @@
           "type": "blockquote",
           "id": "104"
         }]
+      },
+      "category": {
+        "data": [{
+          "type": "taxonomy",
+          "id": "301"
+        }]
       }
     }
   },
@@ -42,6 +48,14 @@
     "attributes": {
       "src": "/path/to/image.jpg",
       "alt": "You do provide ALT values, right?"
+    },
+    "relationships": {
+      "author": {
+        "data": {
+          "type": "person",
+          "id": "202"
+        }
+      }
     }
   },{
     "type": "paragraph",
@@ -76,6 +90,39 @@
           "type": "taxonomy",
           "id": "301"
         }]
+      },
+      "roles": {
+        "data": [{
+          "type": "role",
+          "id": "401"
+        }]
+      }
+    }
+  },{
+    "type": "person",
+    "id": "202",
+    "attributes": {
+      "name": "Foto McFotoface",
+      "biography": "It’s film gran all the way down, friend.",
+      "path": {
+        "alias": "/authors/foto-mcfotoface"
+      }
+    },
+    "relationships": {
+      "topics": {
+        "data": [{
+          "type": "taxonomy",
+          "id": "301"
+        }]
+      },
+      "roles": {
+        "data": [{
+          "type": "role",
+          "id": "401"
+        },{
+          "type": "rule",
+          "id": "402"
+        }]
       }
     }
   },{
@@ -85,6 +132,24 @@
       "name": "Test-driven Development",
       "path": {
         "alias": "/topics/test-driven-development"
+      }
+    }
+  },{
+    "type": "role",
+    "id": "401",
+    "attributes": {
+      "name": "Writer",
+      "path": {
+        "alias": "/writers"
+      }
+    }
+  },{
+    "type": "role",
+    "id": "402",
+    "attributes": {
+      "name": "Photographer",
+      "path": {
+        "alias": "/photographers"
       }
     }
   }]

--- a/test/map.spec.js
+++ b/test/map.spec.js
@@ -56,8 +56,8 @@ describe('Jsonmonger#map', () => {
       url: included[4].attributes.path.alias,
       topics: [{
         type: 'topic',
-        label: included[5].attributes.name,
-        url: included[5].attributes.path.alias,
+        label: included[6].attributes.name,
+        url: included[6].attributes.path.alias,
       }],
     });
   });

--- a/test/model/fetch.js
+++ b/test/model/fetch.js
@@ -94,4 +94,19 @@ describe('fetch() method', () => {
       });
     });
   });
+
+  it('should use the model’s default if set', () => {
+    const PostWithRelated = require('../fixtures/models/Post')({
+      axios,
+      related: [ 'author', 'topics' ],
+    });
+
+    return new PostWithRelated({ id }).fetch().then(() => {
+      expect(axios).to.be.calledOnce;
+      expect(axios).to.be.calledWith({
+        method: 'get',
+        url: 'https://some.contrived.url/posts/1234?include=author,category',
+      });
+    });
+  });
 })

--- a/test/model/fetch.js
+++ b/test/model/fetch.js
@@ -4,8 +4,6 @@ const expect = chai.expect;
 const sinon = require('sinon');
 chai.use(require('sinon-chai'));
 
-const Model = require('../../model');
-
 describe('fetch() method', () => {
   let axios, base_url, Post, post, id;
 
@@ -23,12 +21,7 @@ describe('fetch() method', () => {
 
     base_url = global[Symbol.for('Jsonmonger.config')].base_url;
 
-    Post = new Model({
-      type: 'post',
-      endpoint: '/posts',
-      title: 'attributes.title',
-      sub_title: 'attributes.sub_title',
-    }, { axios });
+    Post = require('../fixtures/models/Post')({ axios });
   });
 
   afterEach(() => {
@@ -58,6 +51,47 @@ describe('fetch() method', () => {
       // that the original `post` object is also updated.
       expect(post).to.deep.equal(new_post);
       expect(post.__data).to.deep.equal(require('../fixtures/post.json').data);
+    });
+  });
+
+  it('should make a request without relationship parameters', () => {
+    return new Post({ id }).fetch({ related: null }).then(() => {
+      expect(axios).to.be.calledOnce;
+      expect(axios).to.be.calledWith({
+        method: 'get',
+        url: 'https://some.contrived.url/posts/1234',
+      });
+    });
+  });
+
+  it('should request to include one relationship', () => {
+    return new Post({ id }).fetch({ related: 'author' }).then(() => {
+      expect(axios).to.be.calledOnce;
+      expect(axios).to.be.calledWith({
+        method: 'get',
+        url: 'https://some.contrived.url/posts/1234?include=author',
+      });
+    });
+  });
+
+  it('should request to include multiple relationships', () => {
+    return new Post({ id }).fetch({ related: [ 'author', 'body' ] })
+      .then(() => {
+        expect(axios).to.be.calledOnce;
+        expect(axios).to.be.calledWith({
+          method: 'get',
+          url: 'https://some.contrived.url/posts/1234?include=author,body',
+        });
+      });
+  });
+
+  it('should request to include all relationships', () => {
+    return new Post({ id }).fetch({ related: true }).then(() => {
+      expect(axios).to.be.calledOnce;
+      expect(axios).to.be.calledWith({
+        method: 'get',
+        url: 'https://some.contrived.url/posts/1234?include=author,body,category',
+      });
     });
   });
 })

--- a/test/model/relationships.js
+++ b/test/model/relationships.js
@@ -70,45 +70,4 @@ describe('relationships', () => {
 
     expect(blockquote).to.deep.equal(raw_blockquote);
   });
-
-  it('should make a request without relationship parameters', () => {
-    return new Post({ id: '1' }).fetch({ related: null }).then(() => {
-      expect(axios).to.be.calledOnce;
-      expect(axios).to.be.calledWith({
-        method: 'get',
-        url: 'https://some.contrived.url/posts/1',
-      });
-    });
-  });
-
-  it('should request to include one relationship', () => {
-    return new Post({ id: '1' }).fetch({ related: 'author' }).then(() => {
-      expect(axios).to.be.calledOnce;
-      expect(axios).to.be.calledWith({
-        method: 'get',
-        url: 'https://some.contrived.url/posts/1?include=author,author.roles',
-      });
-    });
-  });
-
-  it('should request to include multiple relationships', () => {
-    return new Post({ id: '1' }).fetch({ related: [ 'author', 'body' ] })
-      .then(() => {
-        expect(axios).to.be.calledOnce;
-        expect(axios).to.be.calledWith({
-          method: 'get',
-          url: 'https://some.contrived.url/posts/1?include=author,author.roles,body,body.credit',
-        });
-      });
-  });
-
-  it('should request to include all relationships', () => {
-    return new Post({ id: '1' }).fetch({ related: true }).then(() => {
-      expect(axios).to.be.calledOnce;
-      expect(axios).to.be.calledWith({
-        method: 'get',
-        url: 'https://some.contrived.url/posts/1?include=author,author.roles,body,body.credit,category',
-      });
-    });
-  });
 });


### PR DESCRIPTION
This PR implements fetching with relationships (#3) as an opt-in feature of the `Model.fetch()` method. This is accomplished via an options object passed to the `fetch()` method with a `related` key whose value indicates which related records should be fetched along with the main record.

Given the following model…
```javascript
const Model = require('jsonmonger').Model;
const Author = new Model({
  name: 'attributes.full_name',
  books: 'relationships.authored_works',
  topics: 'relationships.authored_categories',
  influences: 'relationships.influences',
});
```

… the value of the `related` key in the `.fetch()` options object can be any one of the following:
- **a string:** `author.fetch({ related: 'books' })` fetches the main JSON record with all records in the `authored_works` relationship.
- **an array of strings:** `author.fetch({ related: [ 'books', 'influences' ] })` fetches the main JSON record with all records in the `authored_works` and `influences` relationships.
- **a boolean:** `author.fetch({ related: true })` fetches the main JSON record with all records in the `authored_works`, `authored_categories`, and `influences` relationships.

By default, no relationships are included in the request if `related` is not set in `.fetch()`, but a default can be set at the model level:
```javascript
const Author = new Model({
  /* model props */
}, {
  related: true,
});
```

The `Author` model’s default behavior will be to fetch all related records. This behavior can still be overridden in the `.fetch()` call’s options object.